### PR TITLE
Update eventhub lab instructions with missing nuget dependency

### DIFF
--- a/Messaging/Lab-2-EventHub/README.md
+++ b/Messaging/Lab-2-EventHub/README.md
@@ -174,6 +174,7 @@ Read through the code and ensure you understand the structure of how the applica
     + Search for `Microsoft.Azure.EventHubs`
     + Select the package and click Install
     + Click **OK** in the Preview Changes window, and accept the licenses.
+    + Repeat the above steps to install `Microsoft.Azure.EventHubs.Processor`
 1. Open the **Program.cs** file, and paste the following:
     ```cs
     using Microsoft.Azure.EventHubs;


### PR DESCRIPTION
While working through the messaging lab, in the EventHub lab, the SimpleEventProcessor cannot implement the given interface because of a missing dependency. This dependency is added in the solution but not in the guide.