### PR TITLE
useHttps is set to true (#1)

### DIFF
--- a/Azure Storage and SQL/README.md
+++ b/Azure Storage and SQL/README.md
@@ -375,7 +375,7 @@ First, we'll add a class that contains the logic to connect to and use Azure Sto
         {
             //Account
             CloudStorageAccount storageAccount = new CloudStorageAccount(
-                new StorageCredentials(this.settings.StorageAccount, this.settings.StorageKey), false);
+                new StorageCredentials(this.settings.StorageAccount, this.settings.StorageKey), true);
 
             //Client
             CloudTableClient tableClient = storageAccount.CreateCloudTableClient();


### PR DESCRIPTION
In order to have a secure storage account, Secure transfer required will be enabled by default. When we access the storage account using the REST API call, we can only connect using HTTPs. (Any requests using HTTP will be rejected when 'secure transfer required' is enabled.). So useHttps must be set to **true**. Without this we get the error : Storage account - The account being accessed does not support http